### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/chench/52943497-cf36-4b3a-99d6-d4ad5891dc41/95376990-85da-4cf4-aa90-7d7d69f9b685/_apis/work/boardbadge/7cdf8de5-1589-4e16-9ffb-572a1583969f)](https://codedev.ms/chench/52943497-cf36-4b3a-99d6-d4ad5891dc41/_boards/board/t/95376990-85da-4cf4-aa90-7d7d69f9b685/Microsoft.RequirementCategory)
 # test
 a
 asda


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/chench/52943497-cf36-4b3a-99d6-d4ad5891dc41/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.