### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/chench/dc250c77-94c6-4627-8a4f-96c0ec3b5418/d4c0c85a-507b-43ce-8a1e-24ba339c0593/_apis/work/boardbadge/6dd54708-a068-4a12-9192-9a565fa9f576)](https://codedev.ms/chench/dc250c77-94c6-4627-8a4f-96c0ec3b5418/_boards/board/t/d4c0c85a-507b-43ce-8a1e-24ba339c0593/Microsoft.RequirementCategory)
 # test
 a
 asda


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/chench/dc250c77-94c6-4627-8a4f-96c0ec3b5418/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.