### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/chench/0ad87a81-535a-4a71-82b7-1c52152cf695/02ba20c1-75dd-4b29-b164-8aa7fed5f408/_apis/work/boardbadge/b61155f4-6061-44d8-a7d5-7309be25708b)](https://codedev.ms/chench/0ad87a81-535a-4a71-82b7-1c52152cf695/_boards/board/t/02ba20c1-75dd-4b29-b164-8aa7fed5f408/Microsoft.RequirementCategory)
 # test
 a
 asda


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/chench/0ad87a81-535a-4a71-82b7-1c52152cf695/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.