### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://witiq.visualstudio.com/4a39283b-15f9-4749-8aa0-751bc259272b/6c9eee08-ca07-485e-b355-fa685450f89b/_apis/work/boardbadge/d87d8e5c-fa1a-46f4-a507-55ff68a5b9ed)](https://witiq.visualstudio.com/4a39283b-15f9-4749-8aa0-751bc259272b/_boards/board/t/6c9eee08-ca07-485e-b355-fa685450f89b/Microsoft.RequirementCategory)
 # test
 a
 asda


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3915651](https://witiq.visualstudio.com/4a39283b-15f9-4749-8aa0-751bc259272b/_workitems/edit/3915651). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.